### PR TITLE
Use license from shadowtraffic examples to power demos

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shadowtraffic-examples"]
+	path = shadowtraffic-examples
+	url = https://github.com/ShadowTraffic/shadowtraffic-examples.git

--- a/retail/docker-compose.yaml
+++ b/retail/docker-compose.yaml
@@ -112,5 +112,6 @@ services:
         source: "./shadowtraffic"
         target: /etc/shadowtraffic
         read_only: true
+    env_file: "shadowtraffic/free-trial-license.env"
     command: --config /etc/shadowtraffic/datagen.json --seed 1234
     restart: on-failure

--- a/retail/shadowtraffic/free-trial-license.env
+++ b/retail/shadowtraffic/free-trial-license.env
@@ -1,0 +1,1 @@
+../../shadowtraffic-examples/free-trial-license.env


### PR DESCRIPTION
Shadowtraffic maintain a license file for use with their examples. This PR uses the same license to power ours. By doing this we ensure we will never use our full license but will always be using a valid trial 