### PR TITLE
Make environment/pipeline writable to other

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -30,6 +30,7 @@ then
     rm -rf $SCRIPT_DIR/../environment/pipeline
 fi
 mkdir -p $SCRIPT_DIR/../environment/pipeline
+chmod o+rw $SCRIPT_DIR/../environment/pipeline
 
 
 # fetch shadowtraffic license


### PR DESCRIPTION
The "confluentinc/cp-kafka-connect" docker image has been changed to run as the "appuser" account (UID 1000) and no longer runs as root (UID 0). Therefore I noticed that the 1_slow_data use case fails to transport any data into the MySQL streambased transactions table as the connect sink cannot write to /tmp/pipeline on the "connect" container.

It looks as though this may have been introduced in version 6.0.5 of the Confluent Platform Containers: https://docs.confluent.io/legacy/platform/6.0/release-notes/changelog.html#version-6-0-5

The solution is not ideal as it makes the folder readable and writable to all, but I felt that as pipeline is a temporal subfolder that should be removed when the demo environment is stopped and that it is difficult to control the UID across the Confluent  Kafka Connect and MySQL containers that this was probably an acceptable risk. 